### PR TITLE
Create simple lib to import so Go projects can vendor the JSTag repo

### DIFF
--- a/serve.go
+++ b/serve.go
@@ -1,0 +1,37 @@
+package jstag
+
+import (
+	"flag"
+	"fmt"
+	"net/http"
+	"os"
+
+	log "github.com/Sirupsen/logrus"
+)
+
+/*Simple static asset service to import github.com/lytics/jstags into Go projects
+so vendoring tools can lock to a jstag checkout. */
+
+func outPath() string {
+	flg := flag.String("outpath", "", "Path to .../jstag/out/ directory containing files to be served")
+	flag.Parse()
+
+	log.Info(fmt.Sprintf("flg: %s", *flg))
+	if *flg != "" {
+
+		return *flg
+	}
+	log.Error("-outpath not set!")
+	os.Exit(1)
+	return ""
+}
+
+func ServeOut() {
+
+	dir := outPath()
+	log.Infof("Out Directory: `%s`", dir)
+
+	log.Info("Listening on port 8080")
+	log.Fatal(http.ListenAndServe(":8080", http.FileServer(http.Dir(dir))))
+
+}


### PR DESCRIPTION
By adding importable Go code to the repo; vendoring tools can lock to a
checkout of the JSTag repostiory and handle it accordingly by importing
it into a project.

Allows Go vendoring tools to manage checkout of JSTag repository.