### PR TITLE
allow loadid overwrite

### DIFF
--- a/src/files/io.js
+++ b/src/files/io.js
@@ -33,7 +33,7 @@
     , id: undefined
     , cid : undefined
     , getid : makeid
-    , loadid: false
+    , loadid: undefined
     , serializer:toString
     , pipeline:['identity','analyze']
     , delay:2000


### PR DESCRIPTION
with the new extend stuff we did a while back having false here redefines loaded as false even if its set to true on config, this should fix / prevent any downstream blowups.

cc @araddon @DingoEatingFuzz 